### PR TITLE
Adding option to set fetch credentials to use cookies

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ module.exports = function (params) {
           query: query,
           variables: variables
         }),
-        headers: headers
+        headers: headers,
+        credentials: params.credentials
       }).then(function (res) {
         return res.json()
       }).then(function (data) {


### PR DESCRIPTION
According to the docs: https://github.com/github/fetch to send cookies for the current domain and presrve the session, the credentials option must be set to `'same-domain'` or `'include'` to allow CORS.
