### PR TITLE
Fix Cannot read property 'line' of undefined when error missing location

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function highlightQuery (query, errors) {
 
   query.split('\n').forEach(function (row, index) {
     var line = index + 1
-    var lineErrors = locations.filter(function (loc) { return loc.line === line })
+    var lineErrors = locations.filter(function (loc) { if(loc) return loc.line === line })
 
     queryHighlight += row + '\n'
 


### PR DESCRIPTION
When an error is returned by a query that does not have a location it causes an error when trying to find the line of the location. Adding check if loc, which allows the error to pass through to the result.