### PR TITLE
Edge Browser Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (params) {
   require('isomorphic-fetch')
   if (!params.url) throw new Error('Missing url parameter')
 
-  var headers = new Headers(params.headers)
+  var headers = new Headers(params.headers || {})
   headers.append('Content-Type', 'application/json')
 
   return {


### PR DESCRIPTION
If you init the client without passing in `headers`, it will break on Microsoft Edge browser.

This is because the Headers() constructor does not accept `undefined` as input in Edge, so there will be an uncaught error. An empty object can be passed into the constructor instead