### PR TITLE
Update isomorphic-fetch, allow fetch implementation to be passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ function highlightQuery (query, errors) {
   return queryHighlight
 }
 
-module.exports = function (params) {
-  require('isomorphic-fetch')
+module.exports = function (params, fetch) {
+  if (!fetch) fetch = require('isomorphic-fetch')
   if (!params.url) throw new Error('Missing url parameter')
 
   var headers = new Headers(params.headers || {})
@@ -41,17 +41,16 @@ module.exports = function (params) {
   return {
     query: function (query, variables, onResponse) {
 
-      var req = new Request(params.url, {
+      return fetch(params.url, {
         method: 'POST',
         body: JSON.stringify({
           query: query,
           variables: variables
         }),
         headers: headers,
-        credentials: params.credentials
+        credentials: params.credentials,
+        agent: params.agent
       })
-
-      return fetch(req)
       .then(function (res) {
         onResponse && onResponse(req, res)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/nordsimon/graphql-client/pull/10 is favourable if working with node backend and `isomorphic-fetch`, but it wasn't on my environment.

Allows the fetch implementation to be passed in, as `isomorphic-fetch` was seemingly ignoring proxy/agent settings.

```
import GQLClient from "graphql-client"
import HttpsProxyAgent from "https-proxy-agent"
import node_fetch from "node-fetch"

var c = GQLClient({
  url : "http://<host>",
  agent: new HttpsProxyAgent(url.parse("http://127.0.0.1:8080"))
}, node_fetch)
```

